### PR TITLE
Update segregating-jenkins-agents-on-kubernetes.md

### DIFF
--- a/content/posts/cicd-with-kubernetes/segregating-jenkins-agents-on-kubernetes.md
+++ b/content/posts/cicd-with-kubernetes/segregating-jenkins-agents-on-kubernetes.md
@@ -207,7 +207,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: pods-all
+  name: jenkins-agents
 subjects:
 - kind: ServiceAccount
   name: jenkins


### PR DESCRIPTION
I haven't tried this yet but shouldn't this be the new jenkins-agent role vs pods-all that isn't mentioned in the article?